### PR TITLE
Fixed SwingTextTerminal memory leak

### DIFF
--- a/text-io/src/main/java/org/beryx/textio/swing/SwingTextTerminal.java
+++ b/text-io/src/main/java/org/beryx/textio/swing/SwingTextTerminal.java
@@ -34,6 +34,7 @@ import java.io.InputStream;
 import java.net.URL;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -104,6 +105,12 @@ public class SwingTextTerminal extends AbstractTextTerminal<SwingTextTerminal> {
         boolean superscript;
         String fontFamily = "Courier New";
         int fontSize = DEFAULT_FONT_SIZE;
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(color, bgColor, bold, italic, underline, strikeThrough, subscript,
+                    superscript, fontFamily, fontSize);
+        }
     }
 
 

--- a/text-io/src/main/java/org/beryx/textio/swing/SwingTextTerminal.java
+++ b/text-io/src/main/java/org/beryx/textio/swing/SwingTextTerminal.java
@@ -92,7 +92,6 @@ public class SwingTextTerminal extends AbstractTextTerminal<SwingTextTerminal> {
     private final StyledDocument document;
     private final StyleData promptStyleData = new StyleData();
     private final StyleData inputStyleData = new StyleData();
-    private int styleCount = 0;
 
     private static class StyleData {
         Color color;
@@ -539,11 +538,12 @@ public class SwingTextTerminal extends AbstractTextTerminal<SwingTextTerminal> {
     }
 
     public String getStyle(StyleData styleData) {
-        Style defaultStyle = StyleContext.getDefaultStyleContext().getStyle(StyleContext.DEFAULT_STYLE);
-
-        styleCount++;
-        String styleName = "style-" + styleCount;
-        Style style = document.addStyle(styleName, defaultStyle);
+        String styleName = String.valueOf(styleData.hashCode());
+        Style style = document.getStyle(styleName);
+        if (style == null) {
+            Style defaultStyle = StyleContext.getDefaultStyleContext().getStyle(StyleContext.DEFAULT_STYLE);
+            style = document.addStyle(styleName, defaultStyle);
+        }
 
         if(styleData.fontFamily != null) {
             StyleConstants.setFontFamily(style, styleData.fontFamily);


### PR DESCRIPTION
When a `SwingTextTerminal` calls `getStyle(StyleData)`, it _always_ adds a new style to it's `Document`. After a couple thousand lines of printed text, the unnecessary references start to cause issues. This change modifies the style name to be a hashcode of the style, and only adds a new style to its document when `document.getStyle(<hash>)` returns null.

Test code (which, in a perfect world, takes 20 seconds to run):
```java
import org.beryx.textio.TextIO;
import org.beryx.textio.TextIoFactory;
import org.beryx.textio.swing.SwingTextTerminal;

import java.awt.*;
import java.util.concurrent.atomic.AtomicInteger;

public class Main {
    public static void main(String[] args) throws Exception {
        TextIO io = TextIoFactory.getTextIO();
        SwingTextTerminal terminal = (SwingTextTerminal) io.getTextTerminal();
        terminal.display();
        long initialTime = System.nanoTime();

        for (int i = 0; i < 100; i++) {
            EventQueue.invokeAndWait(() -> spam(terminal));

            // Delay so the text actually appears in the terminal
            Thread.sleep(200);

            terminal.resetToOffset(0);
        }

        double timeInSeconds = (System.nanoTime() - initialTime) / 1000000000.0;
        System.out.println("Elapsed time: " + timeInSeconds);
    }

    private static void spam(SwingTextTerminal t) {
        for (int i = 0; i < 100; i++) {
            t.println("This text is long enough to fill up the entire line.");
        }
    }
}
```

Output before PR: `Elapsed time: 141.755707654`

Output after PR: `Elapsed time: 20.540818568`

_Note:_ I'm not quite sure if this change breaks anything else, as I don't have the most knowledge of Swing. I was experiencing trouble in an application I'm developing with this library and used [YourKit](https://www.yourkit.com/) to analyze the program, and it led me straight to the `getStyle()` method. As soon as I implemented this change, the problem went away, and as far as I could tell, there weren't any side effects. Let me know if there's anything else I need to modify to improve this PR.