### PR TITLE
Separate Line With A Decorator

### DIFF
--- a/text-io/src/main/java/org/beryx/textio/TextTerminal.java
+++ b/text-io/src/main/java/org/beryx/textio/TextTerminal.java
@@ -183,7 +183,7 @@ public interface TextTerminal<T extends TextTerminal<T>> {
      * the decorator does not need to be a single character ie : '*' ... it could also be ie '+++' if desired.
      */
     default void separateLineWithDecorator(String s, int length) {
-        String separator = s;
+        String separator = "";
         for (int i = 0; i < length; i++){
             separator = separator + s;
         }

--- a/text-io/src/main/java/org/beryx/textio/TextTerminal.java
+++ b/text-io/src/main/java/org/beryx/textio/TextTerminal.java
@@ -178,6 +178,20 @@ public interface TextTerminal<T extends TextTerminal<T>> {
     }
 
     /**
+     * Prints a decorated line separator with a character of choice determined by the String parameter.
+     * the length parameter dictates how many characters the decorator should be.
+     * the decorator does not need to be a single character ie : '*' ... it could also be ie '+++' if desired.
+     */
+    default void separateLineWithDecorator(String s, int length) {
+        String separator = s;
+        for (int i = 0; i < length; i++){
+            separator = separator + s;
+        }
+        print(separator);
+        println();
+    }
+
+    /**
      * Prints each message in the list, inserting the line separator string between messages.
      * No separator string is printed after the last message.
      * The messages in the list may contain line separators.


### PR DESCRIPTION
Added a line separator with a desired text decorator function. The user can separate lines in the command line UI with any character or a string ie: 'X' or '+++' and then set a second parameter of length that would determine how many characters the decorated separator would be.