### PR TITLE
Executes the builds much more quickly by Gradle Daemon

### DIFF
--- a/travis-build.sh
+++ b/travis-build.sh
@@ -1,24 +1,23 @@
 #!/bin/bash
 set -ev
-./gradlew --no-daemon -i -s build javadoc asciidoc
+./gradlew --daemon -i -s build javadoc asciidoc
 
 
 if [ "${TRAVIS_PULL_REQUEST}" == "false" -a "${TRAVIS_BRANCH}" == "master" ]; then
   if [ "`git ls-remote origin gh-pages`" == "" ]; then
     echo Start gitPublishPush with ghPageType=init
-    ./gradlew --no-daemon -i -s gitPublishPush --rerun-tasks -PghPageType=init
+    ./gradlew --daemon -i -s gitPublishPush --rerun-tasks -PghPageType=init
     echo Finished gitPublishPush with ghPageType=init
   fi
     echo Start gitPublishPush with ghPageType=latest
-  ./gradlew --no-daemon -i -s gitPublishPush --rerun-tasks -PghPageType=latest
+  ./gradlew --daemon -i -s gitPublishPush --rerun-tasks -PghPageType=latest
     echo Finished gitPublishPush with ghPageType=version
 
     echo Start gitPublishPush with ghPageType=version
-   ./gradlew --no-daemon -i -s gitPublishPush --rerun-tasks -PghPageType=version
+   ./gradlew --daemon -i -s gitPublishPush --rerun-tasks -PghPageType=version
    echo Finished gitPublishPush with ghPageType=version
 
     echo Start updating releases.md
-   ./gradlew --no-daemon -i -s update-release-list gitPublishPush --rerun-tasks -PghPageType=list
+   ./gradlew --daemon -i -s update-release-list gitPublishPush --rerun-tasks -PghPageType=list
    echo Finished updating releases.md
 fi
-


### PR DESCRIPTION

[Gradle daemon](https://docs.gradle.org/current/userguide/gradle_daemon.html#header). The Daemon is a long-lived process that help to avoid the cost of JVM startup for every build. Since Gradle 3.0, Gradle daemon is enabled by default. For an older version, you should enable it by setting `org.gradle.daemon=true`.

=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.
